### PR TITLE
Introducing matrix build

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -5,9 +5,9 @@ name: Java CI with Gradle
 
 on:
   push:
-#    branches: [ master ]
+    branches: [ master ]
   pull_request:
-#    branches: [ master ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -5,9 +5,9 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ master ]
+#    branches: [ master ]
   pull_request:
-    branches: [ master ]
+#    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -13,13 +13,15 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java-version: [ 11, 17 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v1
         with:
-          java-version: 17
+          java-version: ${{ matrix.java-version }}
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle and run cucumber

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 Quotes Language: German
 
-* Java 17
+* Java 11
 * Gradle 8.1
 
 ## Fallstricke


### PR DESCRIPTION
README.markdown states that Java 17 is needed, neither the code nor the environment seems to have the need for Java 17. 

This PR introduces matrix build to build using Java 11 and Java 17, both are working, you can see the action run here https://github.com/pfichtner/nerd-golf-tracker/actions/runs/5561502510 (I had to disable the branch restriction temporarily in my workflow)